### PR TITLE
Fix : 최초 랜더링 시 스크롤 위치 조정

### DIFF
--- a/src/pages/GameDetail.js
+++ b/src/pages/GameDetail.js
@@ -25,7 +25,10 @@ const GameDetail = () => {
           setGame(gameInfo)
           setGameImage(`assets/GameImage/${gameId}.png`)
         })
-        .catch((error) => console.error('error :', error.message));
+        .catch((error) => console.error('error :', error.message))
+        .finally(() => {
+          window.scrollTo(0, 0);
+        });
     }
   }, [gameId])
 


### PR DESCRIPTION
게임 디테일 페이지 렌더링 시, 페이지의 중앙 부분이 보여지던 문제 해결, 이제 제일 상단 페이지가 보여짐