### PR TITLE
Fix : 재검색 버그 수정

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -13,6 +13,7 @@ export const SearchBar = (props) => {
     e.preventDefault();
 
     setSearchedTerm(userInput);
+    console.log(userInput);
   };
 
   const handleClear = () => {
@@ -25,11 +26,13 @@ export const SearchBar = (props) => {
     const newFilteredGames = allGames.filter((game) =>
       game.game_name.toLowerCase().includes(searchedTerm.toLowerCase())
     );
-
     if (newFilteredGames.length === 0) {
       setFilteredGames([]);
     } else {
       setFilteredGames(newFilteredGames);
+    }
+    if (searchedTerm === '') {
+      setFilteredGames([]);
     }
   }, [searchedTerm])
 


### PR DESCRIPTION
문제 : 검색 기능 사용 후, 기존 검색어를 지워 검색어를 없앤 상황에서 재검색 시, 모든 게임 목록이 보이는 문제 발생
원인 : 검색어가 빈 문자열인 경우, 필터링된 게임 목록을 초기화 하지 않음.
해결 : 검색 버튼을 눌러 검색어(searchedTerm)가 변경 될 때, 검색어가 빈 문자열이라면 필터링된 게임 목록(filteredGames)을 빈 배열로 초기화